### PR TITLE
add grpc health probe service

### DIFF
--- a/grpc/health/v1/health.proto
+++ b/grpc/health/v1/health.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+package grpc.health.v1;
+
+message HealthCheckRequest {
+  string service = 1;
+}
+
+message HealthCheckResponse {
+  enum ServingStatus {
+    UNKNOWN = 0;
+    SERVING = 1;
+    NOT_SERVING = 2;
+    SERVICE_UNKNOWN = 3;  // Used only by the Watch method.
+  }
+  ServingStatus status = 1;
+}
+
+service Health {
+  rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
+  rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse);
+}


### PR DESCRIPTION
Add the service displayed in the grpc documentation so k8s can launch probe on the master server.
https://github.com/grpc/grpc/blob/master/doc/health-checking.md