### PR TITLE
add option to get report unary request

### DIFF
--- a/scoretrak/report/v1/report.proto
+++ b/scoretrak/report/v1/report.proto
@@ -13,7 +13,12 @@ message GetRequest {}
 message GetResponse {
   Report report = 1;
 }
+message GetUnaryRequest {}
+message GetUnaryResponse {
+  Report report = 1;
+}
 
 service ReportService {
   rpc Get(GetRequest) returns (stream GetResponse) {}
+  rpc GetUnary(GetRequest) returns (GetUnaryResponse) {}
 }

--- a/scoretrak/report/v1/report.proto
+++ b/scoretrak/report/v1/report.proto
@@ -20,5 +20,5 @@ message GetUnaryResponse {
 
 service ReportService {
   rpc Get(GetRequest) returns (stream GetResponse) {}
-  rpc GetUnary(GetRequest) returns (GetUnaryResponse) {}
+  rpc GetUnary(GetUnaryRequest) returns (GetUnaryResponse) {}
 }


### PR DESCRIPTION
Add the option to get report once via unary request instead of stream only.